### PR TITLE
menambahkan file requirement.txt

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -1,0 +1,1 @@
+simplejson


### PR DESCRIPTION
simplejson bukan modul default dari installasi python, sehingga terkadang orang yang pakai bertanya tanya, kok ada error? Padahal krn tidak adanya modul.
Untuk itu, mungkin baiknya di tambahi ini, supaya di awal dia langsung menjalankan perintah
untuk isntallasi depennya...
